### PR TITLE
✨ Adicionar registro e visualização de regionalismo

### DIFF
--- a/backend/src/main/java/com/group/backend/controller/RegionalismoController.java
+++ b/backend/src/main/java/com/group/backend/controller/RegionalismoController.java
@@ -1,0 +1,37 @@
+package com.group.backend.controller;
+
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.group.backend.domain.RegionalismoRepository;
+import com.group.backend.entity.ApiPublica;
+import com.group.backend.entity.Regionalismo;
+
+@RequestMapping("/regionalismo")
+@RestController
+@CrossOrigin(origins = "*")
+public class RegionalismoController {
+
+    private final RegionalismoRepository regionalismoRepository;
+
+    public RegionalismoController(RegionalismoRepository regionalismoRepository) {
+        this.regionalismoRepository = regionalismoRepository;
+    }
+    @GetMapping("/listar")
+    public ResponseEntity<List<Regionalismo>> list() {
+        return ResponseEntity.ok(regionalismoRepository.findAll());
+    }
+
+    @PostMapping("/cadastrar")
+    public ResponseEntity<Regionalismo> save(@RequestBody Regionalismo regionalismo) {
+        Regionalismo newRegionalismo = regionalismoRepository.save(regionalismo);
+        return ResponseEntity.ok(newRegionalismo);
+    }
+
+}

--- a/backend/src/main/java/com/group/backend/domain/RegionalismoRepository.java
+++ b/backend/src/main/java/com/group/backend/domain/RegionalismoRepository.java
@@ -1,0 +1,11 @@
+package com.group.backend.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.group.backend.entity.Regionalismo;
+
+@Repository
+public interface RegionalismoRepository extends JpaRepository<Regionalismo, Long> {
+    
+}

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -47,3 +47,33 @@ p {
   font-size: 16px;
   color: #49454F;
 }
+
+.mtb-small {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.mtb-medium {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.plr-small {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.plr-medium {
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
+
+
+.ptb-small {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.pa-medium {
+  padding: 2rem;
+}

--- a/frontend/src/components/CerbButton.vue
+++ b/frontend/src/components/CerbButton.vue
@@ -1,0 +1,65 @@
+<template>
+    <button
+        class="cerb-btn ptb-small plr-small"
+        :class="!fillType || fillType === 'full' ? 'full' : fillType === 'revert' ? 'revert' : 'mute'"
+        :disabled="disabled"
+    >
+        <slot></slot>
+    </button>
+</template>
+
+<script setup lang="ts">
+type Props = {
+    fillType?: 'full' | 'revert' | 'mute'
+    disabled?: boolean
+}
+
+const { fillType, disabled } = defineProps<Props>()
+
+</script>
+
+<style scoped>
+.cerb-btn {
+    border: 0;
+    border-radius: 8px;
+
+    cursor: pointer;
+    transition: all 250ms ease-in-out;
+}
+
+.cerb-btn:disabled {
+    background-color: #c0c0c0;
+    cursor:auto;
+}
+
+.full {
+    background-color: #65558F;
+    color: white;
+}
+
+.full:hover:not(:disabled) {
+    background-color: #9783ca;
+}
+
+.revert {
+    background-color: transparent;
+    color: #65558F;
+}
+
+.revert:disabled {
+    background-color: transparent;
+    color: #c0c0c0;
+}
+
+.revert:hover:not(:disabled) {
+    color: #9783ca;
+}
+
+.mute {
+    background-color: rgb(37, 37, 37);
+    color: white;
+}
+.mute:hover:not(:disabled) {
+    background-color: rgb(82, 82, 82);
+}
+</style>

--- a/frontend/src/components/SideBar.vue
+++ b/frontend/src/components/SideBar.vue
@@ -27,7 +27,8 @@ export default {
         { title: 'Tags', to: '/tags', icon: '@/components/icons/tags-icon.png' },
         { title: 'Notícias', to: '/noticias', icon: '@/components/icons/news-icon.png' },
         { title: 'APIs', to: '/apis', icon: '@/components/icons/apis-icon.png' },
-        { title: 'Portais', to: '/portais', icon: '@/components/icons/portals-icon.png' }
+        { title: 'Portais', to: '/portais', icon: '@/components/icons/portals-icon.png' },
+        { title: 'Regionalismo', to: '/regionalismo', icon: '@/components/icons/portals-icon.png' }
       ]
     };
   }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,6 +1,7 @@
 import ApisView from '@/views/ApisView.vue';
 import HomeView from '@/views/HomeView.vue';
 import PortaisView from '@/views/PortaisView.vue';
+import RegionalismoView from '@/views/RegionalismoView.vue';
 import { createRouter, createWebHistory } from 'vue-router';
 
 const router = createRouter({
@@ -29,6 +30,10 @@ const router = createRouter({
       path: '/apis',
       name: 'apis',
       component: ApisView 
+    },
+    {
+      path: '/regionalismo',
+      component: RegionalismoView
     }
   ]
 });

--- a/frontend/src/views/RegionalismoView.vue
+++ b/frontend/src/views/RegionalismoView.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import CerbButton from '@/components/CerbButton.vue';
+import axios from 'axios';
+import { onMounted, ref } from 'vue';
+
+const tagList = ref<any[]>([])
+
+const relatedTagList = ref<any[]>([])
+const relatedGroupRecord = ref<Record<string, any>>({})
+
+const regionalismoInput = ref()
+const tagSelect = ref()
+
+const resetFields = () => {
+    regionalismoInput.value = ''
+    tagSelect.value = ''
+}
+
+const groupBy = <T>(array: T[], predicate: (value: T, index: number, array: T[]) => string) =>
+    array.reduce((acc, value, index, array) => {
+        (acc[predicate(value, index, array)] ||= []).push(value);
+        return acc;
+    }, {} as { [key: string]: T[] });
+
+const fetch = () => {
+    axios.get('http://localhost:8080/tags/listar').then((res) => {
+        tagList.value = res.data
+    })
+    axios.get('http://localhost:8080/regionalismo/listar').then((res) => {
+        relatedTagList.value = res.data
+        relatedGroupRecord.value = groupBy(res.data, (data: any) => data.tag.tagNome)
+    })
+}
+
+const save = () => {
+    axios.post('http://localhost:8080/regionalismo/cadastrar', {
+        tagId: tagSelect.value,
+        nome: regionalismoInput.value
+    }).then(() => fetch())
+}
+
+onMounted(() => {
+    fetch()
+})
+
+</script>
+
+<template>
+    <div class="wrapper">
+        <div>
+            <div class="d-flex plr-medium ptb-small flex-column border-1">
+                <h2>Cadastar Regionalismos</h2>
+                <h4>Regionalismo</h4>
+                <span class="d-flex mtb-small justify-stretch">
+                    <input v-model="regionalismoInput" class="w-100 plr-small border-1 h-medium" type="text"/>
+                </span>
+                <div class="d-flex flex-column mtb-small w-33">
+                    <div>Tag relacionadas</div>
+                    <select v-model="tagSelect" class="h-medium plr-small mtb-small border-1 bg-trasparent">
+                        <option v-for="(tag, i) in tagList" :key="i" :value="tag.tagId"> {{ tag.tagNome }} </option>
+                    </select>
+                </div>
+                <div class="mtb-small d-flex flex-gap-1">
+                    <CerbButton :disabled="!regionalismoInput || !tagSelect" @click="save">Salvar</CerbButton>
+                    <CerbButton fill-type="revert" @click="resetFields">Cancelar</CerbButton>
+                </div>    
+            </div>
+        </div>
+        <div>
+            <h2 class="mtb-medium">Tags com regionalismo conectados</h2>
+            <div class="d-flex align-center plr-medium ptb-small mtb-small justify-between border-1" v-for="(tagName, i) in Object.keys(relatedGroupRecord)" :key="i">
+                <div>
+                    <h4>Tag: {{ tagName }}</h4>
+                    <span>Regionalismos:
+                        <span v-for="regionalismo, i in relatedGroupRecord[tagName]" :key="i">
+                            <span v-if="i > 0">,</span>
+                            {{ regionalismo.nome }}
+                        </span>
+                    </span>
+                </div>
+                <div>
+                    <CerbButton fill-type="mute">Editar</CerbButton>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+.border-1 {
+    border: 1px solid #cdc6d8;
+}
+.d-flex {
+    display: flex;
+}
+.flex-gap-1 {
+    gap: 1rem;
+}
+.flex-column {
+    flex-direction: column;
+}
+.justify-stretch {
+    justify-content: stretch;
+}
+.justify-between {
+    justify-content: space-between;
+}
+.align-center {
+    align-items: center;
+}
+.w-100 {
+    width: 100%;
+}
+.w-33 {
+    width: 33%
+}
+.h-medium {
+    height: 2rem;
+}
+.bg-trasparent {
+    background-color: transparent;
+}
+</style>


### PR DESCRIPTION
Feature adicionada seguindo os critérios de requisitos, utilizados DBeaver, Insomnia para teste, sem muitas mais complexidades.

## Detalhes
- O botão de salvar só é habilitado quando o campo regionalismo e tag estão com dados;
- O botão de cancelar limpa os dados;
- Assim que um dado novo é salvo, a pagina realiza o fetch novamente;
- O botão de editar não está fazendo nada, vi que existe uma nova tarefa, então está para o próximo desenvolvedor.