### PR TITLE
🐛 Retirando campos não utilizado de edição de tag

### DIFF
--- a/backend/src/main/java/com/group/backend/domain/DadosAtualizarTag.java
+++ b/backend/src/main/java/com/group/backend/domain/DadosAtualizarTag.java
@@ -1,7 +1,7 @@
 package com.group.backend.domain;
 
 public record DadosAtualizarTag(
-    String tagNome,    // Nome opcional para ser atualizado
-    String tagDescricao,  // Descrição opcional para ser atualizada
-    Boolean tagActive   // Status ativo/inativo opcional para ser atualizado
+    String tagNome,   
+    String tagDescricao,
+    Boolean tagActive
 ) {}

--- a/frontend/src/components/ModalEdicaoTag.vue
+++ b/frontend/src/components/ModalEdicaoTag.vue
@@ -31,12 +31,6 @@
             class="checkboxEdicao"
           />
         </div>
-        <label for="relacionadas">Tags relacionadas</label>
-        <select id="relacionadas" v-model="tagLocal.tagRelacionada" class="modal-select">
-          <option value="agricultura">Agricultura</option>
-          <option value="política">Política</option>
-          <!-- Adicionar outras opções conforme necessário -->
-        </select>
 
         <div class="modal-actions">
           <button type="submit" class="salvar-btn">Salvar</button>
@@ -54,7 +48,7 @@ export default {
   },
   data() {
     return {
-      tagLocal: { ...this.tag } // Cria uma cópia do objeto tag
+      tagLocal: { ...this.tag }
     }
   },
   methods: {
@@ -85,7 +79,7 @@ export default {
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.5); /* Fundo semi-transparente */
+  background: rgba(0, 0, 0, 0.5); 
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
Conforme descrito no card, e devido a adoção da tela sobre regionalismo. Retirei o campo qual, ao tentar editar tag, também era possível correlacionar as tags a outras tags. 

Agora, esse tipo de edição só será possível via tela própria de regionalismo