### PR TITLE
🐛 Fix CRON saving data on same day

### DIFF
--- a/backend/src/main/java/com/group/backend/domain/ApiPublicaRepository.java
+++ b/backend/src/main/java/com/group/backend/domain/ApiPublicaRepository.java
@@ -10,10 +10,10 @@ import com.group.backend.entity.ApiPublica;
 
 @Repository
 public interface ApiPublicaRepository extends JpaRepository<ApiPublica, Long> {
-	@Query(value = "SELECT * FROM api_publica WHERE api_frequencia='diaria' AND api_active=true", nativeQuery = true)
+	@Query(value = "SELECT * FROM api_publica WHERE api_frequencia='diariamente' AND api_active=true", nativeQuery = true)
     ArrayList<ApiPublica> getDailyList();
-	@Query(value = "SELECT * FROM api_publica WHERE api_frequencia='semanal' AND api_active=true", nativeQuery = true)
+	@Query(value = "SELECT * FROM api_publica WHERE api_frequencia='semanalmente' AND api_active=true", nativeQuery = true)
     ArrayList<ApiPublica> getWeeklyList();
-	@Query(value = "SELECT * FROM api_publica WHERE api_frequencia='mensal' AND api_active=true", nativeQuery = true)
+	@Query(value = "SELECT * FROM api_publica WHERE api_frequencia='mensalmente' AND api_active=true", nativeQuery = true)
     ArrayList<ApiPublica> getMonthlyList();
 }

--- a/backend/src/main/resources/db/migration/V3__alterar_periodo_enum.sql
+++ b/backend/src/main/resources/db/migration/V3__alterar_periodo_enum.sql
@@ -1,0 +1,3 @@
+ALTER TABLE api_publica ADD CONSTRAINT valor_frequencia CHECK (api_frequencia IN ('diariamente', 'semanalmente', 'mensalmente'));
+ALTER TABLE portal ADD CONSTRAINT valor_frequencia CHECK (por_frequencia IN ('diariamente', 'semanalmente', 'mensalmente'));
+ALTER TABLE result_api ADD UNIQUE(api_id, res_data);


### PR DESCRIPTION
## Problema 1
Quando uma tarefa do CRON é executada, ele executa uma query para trazer o utilmo resultado salva no banco. Quando o tem dois resultados salvos no mesmo dia, ele traria os dois, e no lugar de retornar um objeto, retorna uma lista de objeto.
### Solução
Adicionar uma nova foreign key com a data do resultado e o id da API relacionada com ele.

## Outras mudanças
Também adicionei uma CONSTRAINT para o valor das frequencias serem fixas em "diaramente", "semanalmente" e "mensalmente"