### PR TITLE
♻️ [US10] Ajusta regra de visita para abranger subdomínios e aprimora logs

### DIFF
--- a/backend/src/main/java/com/group/backend/crawler/ControllerCrawler.java
+++ b/backend/src/main/java/com/group/backend/crawler/ControllerCrawler.java
@@ -19,20 +19,20 @@ public class ControllerCrawler {
     private static final Logger logger = LoggerFactory.getLogger(ControllerCrawler.class);
     private static final String CRAWL_STORAGE_FOLDER = "./dadosCrawler";
     private static final int POLITENESS_DELAY = 1000; // 1 segundo
-    private static final int MAX_PAGES_TO_FETCH = 1000; // Número máximo de páginas a serem buscadas
+    private static final int MAX_PAGES_TO_FETCH = 100; // Número máximo de páginas a serem buscadas
     private static final boolean INCLUDE_BINARY_CONTENT = false; // Não incluir conteúdo binário no crawling
 
-    private NoticiaRepository noticiaRepository; // Adicionando o repositório aqui
-
-    private ReporterRepository reporterRepository; // Adicionando o repositório aqui
+    private NoticiaRepository noticiaRepository;
+    private ReporterRepository reporterRepository;
 
     public ControllerCrawler(NoticiaRepository noticiaRepository, ReporterRepository reporterRepository) {
-        this.noticiaRepository = noticiaRepository; // Inicializando o repositório
-        this.reporterRepository = reporterRepository; // Inicializando o repositório
+        this.noticiaRepository = noticiaRepository;
+        this.reporterRepository = reporterRepository;
     }
 
     public void startCrawlWithSeed(String seedUrl, Noticia noticia, ParserHtml parserHtml, ReporterRepository reporterRepository) {
         try {
+            logger.info("Iniciando processo de crawling com a seed: {}", seedUrl); // Log da seed
             CrawlConfig config = new CrawlConfig();
             config.setCrawlStorageFolder(CRAWL_STORAGE_FOLDER);
             config.setPolitenessDelay(POLITENESS_DELAY);
@@ -59,7 +59,14 @@ public class ControllerCrawler {
 
             // Inicia o crawling
             controller.start(factory, numberOfCrawlers);
+
+            // Verifica o status do controlador e adia o shutdown até todas as URLs serem processadas
+            while (!controller.isFinished()) {
+                Thread.sleep(1000); // Aguarda 1 segundo antes de checar novamente
+            }
             controller.shutdown();
+            logger.info("Crawling finalizado e controller encerrado.");
+            
         } catch (Exception e) {
             logger.error("Erro ao iniciar o crawling: {}", e.getMessage());
         }

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <!-- Console Appender (somente mensagens INFO e superiores) -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- File Appender com Rolling Policy (captura todos os níveis, incluindo DEBUG) -->
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/crawler.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
@@ -11,7 +19,20 @@
         </encoder>
     </appender>
 
+    <!-- Configura os loggers em nível DEBUG apenas para o arquivo de log -->
+    <logger name="com.group.backend.crawler.ControllerCrawler" level="DEBUG" additivity="false">
+        <appender-ref ref="FILE"/>
+    </logger>
+    <logger name="com.group.backend.crawler.MainCrawler" level="DEBUG" additivity="false">
+        <appender-ref ref="FILE"/>
+    </logger>
+    <logger name="com.group.backend.crawler.ParserHtml" level="DEBUG" additivity="false">
+        <appender-ref ref="FILE"/>
+    </logger>
+
+    <!-- Root Logger com nível INFO para o console -->
     <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
         <appender-ref ref="FILE"/>
     </root>
 </configuration>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/crawler.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/crawler-%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory> <!-- Retém 30 dias de logs -->
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="FILE"/>
+    </root>
+</configuration>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8364,19 +8364,8 @@
       }
     },
     "node_modules/spring-vue-monorepo-pipeline-poc": {
-      "version": "0.0.0",
-      "resolved": "file:",
-      "license": "ISC",
-      "workspaces": [
-        "backend",
-        "frontend"
-      ],
-      "dependencies": {
-        "axios": "^1.7.7",
-        "spring-vue-monorepo-pipeline-poc": "file:",
-        "vue-json-pretty": "^2.4.0",
-        "vue-multiselect": "^3.0.0"
-      }
+      "resolved": "",
+      "link": true
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",


### PR DESCRIPTION
Atualiza o método shouldVisit para permitir o crawling de subdomínios dentro do domínio principal extraído da seed.
Adiciona logs detalhados para monitorar o processo de extração e filtragem de URLs (Logs podem ser acessados no caminho: Resources/logs).
🚧 [Ainda precisa de correção]: Ajusta o parser de HTML para extrair corretamente repórteres e tratar links externos.