### PR TITLE
[Us10] construir multiplas conexes para crawler

### DIFF
--- a/backend/src/main/java/com/group/backend/crawler/ControllerCrawler.java
+++ b/backend/src/main/java/com/group/backend/crawler/ControllerCrawler.java
@@ -21,7 +21,7 @@ public class ControllerCrawler {
     private static final String CRAWL_STORAGE_FOLDER = "./dadosCrawler";
     private static final int MAX_PAGES_TO_FETCH = 1000; // Número máximo de páginas a serem buscadas
     private static final boolean INCLUDE_BINARY_CONTENT = false; // Não incluir conteúdo binário no crawling
-    private static final int NUMBER_OF_CRAWLERS = 3; // Número de threads para o crawling
+    private static final int NUMBER_OF_CRAWLERS = 100; // Número de threads para o crawling
     private static final int MIN_POLITENESS_DELAY = 500; // Delay mínimo em milissegundos
     private static final int MAX_POLITENESS_DELAY = 3000; // Delay máximo em milissegundos
 
@@ -58,7 +58,8 @@ public class ControllerCrawler {
 
             int numSeeds = seedUrls.length;
             logger.info("Número total de seeds recebidas: {}", numSeeds);
-            int threads = Math.min(NUMBER_OF_CRAWLERS, numSeeds); // Não criar mais threads do que seeds
+            int availableProcessors = Runtime.getRuntime().availableProcessors();
+            int threads = Math.min(NUMBER_OF_CRAWLERS, availableProcessors * 2); // Ajuste baseado no número de núcleos de CPU
 
             for (int i = 0; i < threads; i++) {
                 final int threadIndex = i; // Variável final para uso no lambda


### PR DESCRIPTION
Objetivo do Teste:

Avaliar o desempenho do crawler sob alta carga de trabalho.
Identificar o ponto de saturação do sistema em termos de uso de CPU e memória.
Configuração do Ambiente:

Servidor com especificações: CPU de múltiplos núcleos e 8GB de memória RAM. Dentro do conteiner
Sistema operacional: Linux.
Ferramentas de monitoramento: htop,.
Configuração do Crawler:

Configurar o crawler para utilizar 100 threads simultâneas.
Garantir que o crawler tenha uma lista de URLs suficientemente grande para processar.
Execução do Teste:

Iniciar o monitoramento dos recursos do sistema (CPU, memória, I/O).
Iniciar o crawler com a configuração de 100 threads.
Registrar o tempo de início do teste.
Monitoramento e Coleta de Dados:

Monitorar o uso de CPU e memória durante a execução do crawler.
Registrar picos de uso de CPU e memória.
Observar o comportamento do sistema (lentidão, erros, etc.).
Critérios de Sucesso:

O crawler deve completar a tarefa sem falhas críticas.
Análise dos Resultados:

O sistema rodou sem falhas críticas com 10 URLS cadastradas
Atingiu o limite de 8GB de memória e qual teve um impacto no desempenho. Mas nada alarmente
Possível que deixar a operação assincrona deixe ele ainda mais performático